### PR TITLE
Add ROS 2 Foxy support and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This project aims to develop and maintain ROS2 drivers for the IM1R product.
 ### System Requirements
 
 - Ubuntu 22.04 / ROS2 Humble
+- Ubuntu 20.04 / ROS2 Foxy
 
 ### Installation Setups
 
@@ -74,18 +75,28 @@ This project aims to develop and maintain ROS2 drivers for the IM1R product.
    git clone https://github.com/DAISCHSensor/im1r_ros2_driver.git
    git clone https://github.com/DAISCHSensor/im1r_ros2_interface.git
    ```
+
+5. Install ROS dependencies：
+
+   ```shell
+   cd ~/ros2_ws
+   rosdep install --from-paths src --ignore-src -r -y
+   ```
    
-5. Build the driver:
+6. Build the driver:
 
    ``` shell
    cd ~/ros2_ws/
    colcon build
    ```
 
-6. Update the `.bashrc` file:
+7. Update the `.bashrc` file:
+
+   ⚠️ **Note**: If you've already added these lines to your .bashrc, do not add them again to avoid duplicates.
 
    ``` shell
    echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/<ros-distro>/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 
@@ -98,22 +109,22 @@ This project aims to develop and maintain ROS2 drivers for the IM1R product.
    ``` shell
    sudo dmesg | grep tty
    ```
-
-3. Set the serial port permissions:
+   
    Assuming the IM1R device is connected to /dev/ttyUSB0:
 
    ``` shell
    sudo chmod 666 /dev/ttyUSB0
    ```
 
+3. Confirm the baud rate of the IM1R device. The default baud rate is 115200, which can be modified via the host computer software DS_RVision.
+
 4. Launch the driver node:
+   - Assume the serial port connected to the IM1R is `/dev/ttyUSB0` 
+   - Assume the baud rate used by the IM1R is `115200` 
 
    ``` shell
    ros2 run im1r_ros2_driver im1r_node --ros-args -p serial_port:=/dev/ttyUSB0 -p baud_rate:=115200
    ```
-
-   - `/dev/ttyUSB0` is the serial port.
-   - `115200` is the baud rate used by IM1R, adjust it as needed.
 
 5. List all the topic:
 

--- a/README.md
+++ b/README.md
@@ -94,18 +94,18 @@ This project aims to develop and maintain ROS2 drivers for the IM1R product.
 
    ⚠️ **Note**: If you've already added these lines to your .bashrc, do not add them again to avoid duplicates.
 
-   If your ROS2 version is Foxy
+   For ROS 2 Foxy
    
    ``` shell
-   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
-   If your ROS2 version is Humble
+   For ROS 2 Humble
    
    ``` shell
-   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,18 @@ This project aims to develop and maintain ROS2 drivers for the IM1R product.
 
    ⚠️ **Note**: If you've already added these lines to your .bashrc, do not add them again to avoid duplicates.
 
+   If your ROS2 version is Foxy
+   
    ``` shell
    echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
-   echo "source /opt/ros/<ros-distro>/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+   source ~/.bashrc
+   ```
+   If your ROS2 version is Humble
+   
+   ``` shell
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,16 +97,16 @@
    对于 ROS2  Foxy
    
    ```shell
-   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
    
    对于 ROS2  Humble
    
    ```shell
-   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,10 +93,20 @@
 7. 添加工作空间的环境变量到 `.bashrc`：
 
    ⚠️ **注意：**如果之前已经在 .bashrc 中添加过以下内容，请不要重复添加，以免出现重复加载或配置混乱。
-
+   
+   对于 ROS2  Foxy
+   
    ```shell
    echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
-   echo "source /opt/ros/<ros-distro>/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+   source ~/.bashrc
+   ```
+   
+   对于 ROS2  Humble
+   
+   ```shell
+   echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,6 +45,7 @@
 ### 系统要求
 
 - Ubuntu 22.04 / ROS2 Humble
+- Ubuntu 20.04 / ROS2 Foxy
 
 ### 安装步骤
 
@@ -75,17 +76,27 @@
    git clone https://github.com/DAISCHSensor/im1r_ros2_interface.git
    ```
    
-5. 构建工作空间：
+5. 安装 ROS 依赖项：
+
+   ```shell
+   cd ~/ros2_ws
+   rosdep install --from-paths src --ignore-src -r -y
+   ```
+   
+6. 构建工作空间：
 
    ```shell
    cd ~/ros2_ws/
    colcon build
    ```
 
-6. 添加工作空间的环境变量到 `.bashrc`：
+7. 添加工作空间的环境变量到 `.bashrc`：
+
+   ⚠️ **注意：**如果之前已经在 .bashrc 中添加过以下内容，请不要重复添加，以免出现重复加载或配置混乱。
 
    ```shell
    echo "source ~/ros2_ws/install/setup.bash" >> ~/.bashrc
+   echo "source /opt/ros/<ros-distro>/setup.bash" >> ~/.bashrc
    source ~/.bashrc
    ```
 
@@ -98,22 +109,23 @@
    ``` shell
    sudo dmesg | grep tty
    ```
-
-3. 设置串口权限：
+   
    假设 IM1R 设备连接到 /dev/ttyUSB0：
 
    ``` shell
    sudo chmod 666 /dev/ttyUSB0
    ```
 
+3. 确认 IM1R 设备的波特率，默认波特率是115200，可通过上位机 DS_RVision 来更改
+
 4. 启动驱动节点：
+
+   - 假设当前IM1R连接的串口是 `/dev/ttyUSB0`
+   - 假设当前IM1R使用的波特率是 `115200`
 
    ``` shell
    ros2 run im1r_ros2_driver im1r_node --ros-args -p serial_port:=/dev/ttyUSB0 -p baud_rate:=115200
    ```
-
-   - `/dev/ttyUSB0` 是当前IM1R连接的串口
-   - `115200` 是当前IM1R使用的波特率
 
 5. 列出所有话题：
 

--- a/im1r_ros2_driver/parser.py
+++ b/im1r_ros2_driver/parser.py
@@ -12,7 +12,8 @@ CMD_LEN = 1
 LEN_LEN = 1
 CRC_LEN = 1
 TAIL_LEN = 2
-USED_FRAME_LEN = 68
+FRAME_LEN_OLD = 68
+FRAME_LEN_BINARY = 72
 
 
 def checksum_crc(data, crc_ref):
@@ -40,20 +41,20 @@ def checksum_crc(data, crc_ref):
 # Parse frame data function
 def parse_frame(frame):
 
-    if len(frame) == USED_FRAME_LEN:
+    if len(frame) == FRAME_LEN_OLD:
         head = frame[0:HEAD_LEN]
         dom = frame[HEAD_LEN:HEAD_LEN + DOM_LEN]
         cmd = frame[HEAD_LEN + DOM_LEN:HEAD_LEN + DOM_LEN + CMD_LEN]
         length = frame[HEAD_LEN + DOM_LEN + CMD_LEN:HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN]
 
-        cmd_value = struct.unpack('B', cmd)[0]
+        # cmd_value = struct.unpack('B', cmd)[0]
         Data_Len = struct.unpack('B', length)[0]
 
         data = frame[HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN:HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len]
         crc = frame[HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len:
                     HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len + CRC_LEN]
 
-        if cmd_value == 1 and len(data) == Data_Len and checksum_crc(head + dom + cmd + length + data, crc):
+        if len(data) == Data_Len and checksum_crc(head + dom + cmd + length + data, crc):
             parsed_data = {
                 'Count': struct.unpack('B', data[0:1])[0],
                 'Timestamp': struct.unpack('<Q', data[1:9])[0],
@@ -66,6 +67,10 @@ def parse_frame(frame):
                 'Pitch': struct.unpack('<f', data[33:37])[0],
                 'Roll': struct.unpack('<f', data[37:41])[0],
                 'Yaw': struct.unpack('<f', data[41:45])[0],
+                'Quat0': None,
+                'Quat1': None,
+                'Quat2': None,
+                'Quat3': None,
                 'Temperature': struct.unpack('<h', data[45:47])[0] * 0.1,
                 'IMUStatus': struct.unpack('B', data[47:48])[0],
                 'GyroBiasX': struct.unpack('<h', data[48:50])[0] * 0.0001,
@@ -78,6 +83,50 @@ def parse_frame(frame):
             return parsed_data
         else:
             return None
+        
+    elif len(frame) == FRAME_LEN_BINARY:
+        head = frame[0:HEAD_LEN]
+        dom = frame[HEAD_LEN:HEAD_LEN + DOM_LEN]
+        cmd = frame[HEAD_LEN + DOM_LEN:HEAD_LEN + DOM_LEN + CMD_LEN]
+        length = frame[HEAD_LEN + DOM_LEN + CMD_LEN:HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN]
+
+        # cmd_value = struct.unpack('B', cmd)[0]
+        Data_Len = struct.unpack('B', length)[0]
+
+        data = frame[HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN:HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len]
+        crc = frame[HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len:
+                    HEAD_LEN + DOM_LEN + CMD_LEN + LEN_LEN + Data_Len + CRC_LEN]
+
+        if len(data) == Data_Len and checksum_crc(head + dom + cmd + length + data, crc):
+            parsed_data = {
+                'Count': struct.unpack('B', data[0:1])[0],
+                'Timestamp': struct.unpack('<Q', data[1:9])[0],
+                'AccX': struct.unpack('<f', data[9:13])[0],
+                'AccY': struct.unpack('<f', data[13:17])[0],
+                'AccZ': struct.unpack('<f', data[17:21])[0],
+                'GyroX': struct.unpack('<f', data[21:25])[0],
+                'GyroY': struct.unpack('<f', data[25:29])[0],
+                'GyroZ': struct.unpack('<f', data[29:33])[0],
+                'Pitch': struct.unpack('<f', data[33:37])[0],
+                'Roll': struct.unpack('<f', data[37:41])[0],
+                'Yaw': struct.unpack('<f', data[41:45])[0],
+                'Quat0': struct.unpack('<f', data[45:49])[0],
+                'Quat1': struct.unpack('<f', data[49:53])[0],
+                'Quat2': struct.unpack('<f', data[53:57])[0],
+                'Quat3': struct.unpack('<f', data[57:61])[0],
+                'Temperature': struct.unpack('<h', data[61:63])[0] * 0.1,
+                'IMUStatus': struct.unpack('B', data[63:64])[0],
+                'GyroBiasX': None,
+                'GyroBiasY': None,
+                'GyroBiasZ': None,
+                'GyroStaticBiasX': None,
+                'GyroStaticBiasY': None,
+                'GyroStaticBiasZ': None
+            }
+            return parsed_data
+        else:
+            return None
+        
     else:
         return None
 

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <license>BSD</license>
 
   <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['setuptools', 'rclpy', 'sensor_msgs'],
+    install_requires=['setuptools'],
     zip_safe=True,
     maintainer='daisch',
     maintainer_email='daisch@todo.todo',


### PR DESCRIPTION
Changes Included:
- Updated `setup.py` to remove `rclpy` and `sensor_msgs` from install_requires (Foxy compatibility)
- Added dependency declarations to `package.xml`
- Improved installation documentation for ROS 2 version clarity and user guidance

Tested on:
- Ubuntu 20.04 + ROS 2 Foxy
- Ubuntu 22.04 + ROS 2 Humble
